### PR TITLE
correct helm deploy command, clarify readmes

### DIFF
--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -92,9 +92,9 @@ To list all deployed services:
 
 Note that the "Hello World" example includes a LoadBalancer Kubernetes service that would
 allow you to access its web page from outside the cluster. If your cluster is not configured
-with LoadBalancer support then the service will never get an IP address, and the TOSCA "url"
-output for your "Hello World" service will show `http://<unknown>:80`, even when successfully
-deployed.
+with LoadBalancer support then, even when successfully
+deployed, the service will never get an IP address, and the TOSCA "url"
+output for your "Hello World" service will show `http://<unknown>:80`.
 
 If you're using Minikube, it comes with a
 [primitive ingress solution](https://minikube.sigs.k8s.io/docs/commands/tunnel/) based on ssh
@@ -103,5 +103,4 @@ tunneling that can be useful for testing. To run it (blocking):
     minikube tunnel
 
 Once the tunnel is up, the LoadBalancer should get its IP address, and soon Turandot will
-update the "url" output with the correct URL, which you should be able to access with a
-web browser.
+update the "url" output with the correct URL. A web browser can then be used to access the indicated URL.

--- a/examples/hello-world/README.md
+++ b/examples/hello-world/README.md
@@ -3,23 +3,40 @@ Hello World Example
 
 A stateless single-pod web workload comprising a deployment and a loadbalancer service.
 
+Requirements
+------------
+Ensure to met all the requirements as explained in [QUICKSTART](../QUICKSTART.md), for minikube these can be summarized as: 
+
+    minikube start --addons=registry ...
+    kubectl create namespace workspace
+    kubectl config set-context --current --namespace=workspace
+    turandot operator install --site=central --role=view --wait -v
+    reposure registry create default --provider=minikube --wait -v
 
 Building the CSAR
 -----------------
 
 * [Package as CSAR file](scripts/build-csar)
 
+    examples/hello-world/scripts/build-csar
 
 Deploying
 ---------
 
     turandot service deploy hello-world --file=dist/hello-world.csar
 
+Verifying
+---------
+
+    turandot service list
+
 If you want to access the deployed web server from outside the cluster you will need to have
 loadbalancing supported on your Kubernetes cluster. On Minikube you can just
-[start a tunnel](https://minikube.sigs.k8s.io/docs/handbook/accessing/#using-minikube-tunnel).
+[start a tunnel](https://minikube.sigs.k8s.io/docs/handbook/accessing/#using-minikube-tunnel) in a separate terminal session.
 
-If supported, the "url" output of the service template will work. To open from your default web
+    minikube tunnel
+
+If supported, the "url" output of the service template will show the allocated external address. To open from your default web
 browser:
 
     xdg-open $(turandot service output hello-world url)

--- a/examples/helm/README.md
+++ b/examples/helm/README.md
@@ -8,18 +8,38 @@ Building the CSAR
 -----------------
 
 * [Package the Helm chart](scripts/build-chart)
+
+    examples/helm/scripts/build-chart
+
 * [Package as CSAR file](scripts/build-csar)
+
+    examples/helm/scripts/build-csar
 
 
 Deploying
 ---------
 
-    turandot service deploy helm-hello-world --file=dist/helm-hello-world.csar
+    turandot service deploy helm-hello-world --file=dist/helm.csar
 
+Verifying
+---------
 Note that though Helm is used to create the Kubernetes manifests, Turandot is controlling them.
 The `helm` command line tool will not be able to list the release. Use the `turandot service` command
 instead.
 
+    As in the hello-world example, confirm operation using
+
+  Run minikube tunnel in a separate session
+
+    minikube tunnel
+
+Then get the external IP address
+
+    kubectl get service hello-world-helm
+
+and use it to confirm operation
+
+    curl <external address>:8080
 
 How the Helm Chart Was Created
 ------------------------------

--- a/examples/self-contained/README.md
+++ b/examples/self-contained/README.md
@@ -10,8 +10,12 @@ Building the CSAR
 -----------------
 
 * [Save container images as tarball](scripts/save-container-image)
+
+    examples/self-contained/scripts/save-container-image
+
 * [Package as CSAR file](scripts/build-csar)
 
+    examples/self-contained/scripts/build-csar
 
 Deploying
 ---------
@@ -20,7 +24,7 @@ Deploying
 
 If you want to access the deployed web server from outside the cluster you will need to have
 loadbalancing supported on your Kubernetes cluster. On Minikube you can just
-[start a tunnel](https://minikube.sigs.k8s.io/docs/handbook/accessing/#using-minikube-tunnel).
+[start a tunnel](https://minikube.sigs.k8s.io/docs/handbook/accessing/#using-minikube-tunnel) on a separate terminal session
 
 If supported, the "url" output of the service template will work. To open from your default web
 browser:


### PR DESCRIPTION
As requested here is a revised pull request for [issue 1](https://github.com/tliron/turandot/issues/1) with the commits squashed.

The helm deploy command was mis-named I think. The other clarifications are pretty minor now. 

I did fetch your latest version so I'm not convinced we really were working on the same file at the same time.